### PR TITLE
Fix EADDRINUSE on reconnect

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -108,6 +108,14 @@ const checkBlock = (oldBlock, newBlock) => {
 }
 
 const connect = () => {
+
+    // close existing viewer instance if the bot reconnects to avoid EADDRINUSE
+    if (bot != null) {
+        if (bot.viewer != null) {
+            bot.viewer.close()
+        }
+    }
+
     const instance = mineflayer.createBot(connectionData)
 
     instance.once("spawn", welcome)


### PR DESCRIPTION
On reconnect to the MC server, the prismarine-viewer instance from the previous session will now be shut down properly to avoid EADDRINUSE when creating a new viewer instance for the new MC session